### PR TITLE
Update NuxeoAutomationAPI.php

### DIFF
--- a/NuxeoAutomationClient/NuxeoAutomationAPI.php
+++ b/NuxeoAutomationClient/NuxeoAutomationAPI.php
@@ -176,11 +176,13 @@ class NuxeoDocuments {
         $test = true;
         if (!empty($newDocList['entries'])) {
             while (false !== $test) {
-                $this->documentsList[] = new NuxeoDocument(current($newDocList['entries']));
+            	if (is_array(current($newDocList['entries']))) {
+                    $this->documentsList[] = new NuxeoDocument(current($newDocList['entries']));
+            	}
                 $test = each($newDocList['entries']);
             }
             $test = sizeof($this->documentsList);
-            unset($this->documentsList[$test - 1]);
+            unset($this->documentsList[$test]);
         } elseif (!empty($newDocList['uid'])) {
             $this->documentsList[] = new NuxeoDocument($newDocList);
         } elseif (is_array($newDocList)) {


### PR DESCRIPTION
Ask if is an array the parameter of NuxeoDocument. The last position of $newDocList[] is a boolean and NuxeoDocument gives a warning. 
The sentence each return the current key and value pair from an array and advance the array cursor.
In the next loop $test have an array (the previous position in the array) but current() have a boolean...
